### PR TITLE
Export SwipeableRow

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
 import SwipeableFlatList from './Swipeable/SwipeableFlatList';
 
+export {default as SwipeableRow} from './Swipeable/SwipeableRow';
+
 export default SwipeableFlatList;


### PR DESCRIPTION
We were using the older behavior where the row was exported from library.