### PR TITLE
Fix QuickActions stay on foreground on Android

### DIFF
--- a/Swipeable/SwipeableRow.js
+++ b/Swipeable/SwipeableRow.js
@@ -337,6 +337,7 @@ const styles = StyleSheet.create({
         position: 'absolute',
         right: 0,
         top: 0,
+        zIndex: -1
     },
 });
 


### PR DESCRIPTION
On Android the QuickActions container was always in the foreground, hiding the actual item in the FlatList