### PR TITLE
ignore gifs used in readme for npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ tmp
 
 # Examples
 examples
+images


### PR DESCRIPTION
This should get our package size down from ~3mb to, hopefully, ~18kb. 🙏 