### PR TITLE
Remove AppCenter Build status badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Downloads](https://img.shields.io/npm/dm/react-native-swipeable-list.svg?sanitize=true)](https://npmcharts.com/compare/react-native-swipeable-list?minimal=true)
 ![License](https://img.shields.io/npm/l/react-native-swipeable-list?color=brightgreen)
 ![PRs](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)
-[![Build status](https://build.appcenter.ms/v0.1/apps/13534511-14df-4ea0-b460-22eb6d84e8fe/branches/main/badge)](https://appcenter.ms)
 
 A zero-dependency, Swipeable FlatList for React-Native with Quick Actions, Gestures, and Animations.
 


### PR DESCRIPTION
Cleanup from no longer using Microsoft Appcenter for builds